### PR TITLE
Change metric name from packetLoss to jitter

### DIFF
--- a/cmk_addons_plugins/fortigate_sla/agent_based/fortigate_sla.py
+++ b/cmk_addons_plugins/fortigate_sla/agent_based/fortigate_sla.py
@@ -134,7 +134,7 @@ def check_sla_fortinet(item, params, section) -> CheckResult:
                         label="Jitter: {}".format(
                             item2.LinkJitter,
                         ),
-                        metric_name="fortigate_sla_packetLoss",
+                        metric_name="fortigate_sla_jitter",
                     )
 
     else:


### PR DESCRIPTION
The jitter graph wasnt created as the section for jitter inside the check plugin is referencing for the packetloss metric